### PR TITLE
Add RcppParallel cxxflags to makevars

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -1,2 +1,3 @@
 CXX_STD = CXX11
+PKG_CXXFLAGS += $(shell ${R_HOME}/bin/Rscript -e "RcppParallel::CxxFlags()")
 PKG_LIBS += $(shell ${R_HOME}/bin/Rscript -e "RcppParallel::RcppParallelLibs()")

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,5 +1,6 @@
 CXX_STD = CXX11
 PKG_CXXFLAGS += -DRCPP_PARALLEL_USE_TBB=1
+PKG_CXXFLAGS += $(shell "${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" -e "RcppParallel::CxxFlags()")
 
 PKG_LIBS += $(shell "${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" \
               -e "RcppParallel::RcppParallelLibs()")


### PR DESCRIPTION
This PR updates your Makevars to add RcppParallel's CXXFLAGS, which will be needed for compatibility with Windows ARM64